### PR TITLE
Zero value for bool is false

### DIFF
--- a/derive/types.go
+++ b/derive/types.go
@@ -61,6 +61,8 @@ func Zero(typ types.Type) string {
 		switch t.Kind() {
 		case types.String:
 			return `""`
+		case types.Bool:
+			return "false"
 		default:
 			return "0"
 		}


### PR DESCRIPTION
Zero value for bool should be false

https://tour.golang.org/basics/12

I had an error from a generated deriveComposeFooBar because the final function returned (bool, error) and the derived fn was returning 0, err. 

Here is example code that will fail without the fix.

```go
func foo() (string, error) {
	return "", fmt.Errorf("somethings wrong")
}

func bar(string) (bool, error) {
	return true, nil
}

cat, err := deriveComposeFooBar(
	foo,
	bar,
)()
```

it generates:

```go
func deriveComposeFooBar(f0 func() (string, error), f1 func(string) (bool, error)) func() (bool, error) {
	return func() (bool, error) {
		v_1_0, err0 := f0()
		if err0 != nil {
			return 0, err0
		}
		v_2_0, err1 := f1(v_1_0)
		if err1 != nil {
			return 0, err1
		}
		return v_2_0, nil
	}
}
```

when what we really should have is:

```go
func deriveComposeFooBar(f0 func() (string, error), f1 func(string) (bool, error)) func() (bool, error) {
	return func() (bool, error) {
		v_1_0, err0 := f0()
		if err0 != nil {
			return false, err0
		}
		v_2_0, err1 := f1(v_1_0)
		if err1 != nil {
			return false, err1
		}
		return v_2_0, nil
	}
}
```

I couldn't get the project to build so I wasn't sure how to add a test, so hopefully you can go from what I have here to complete the fix. 

PS. I really like the project!