### PR TITLE
derive: more aggressively check for invalid types

### DIFF
--- a/derive/find.go
+++ b/derive/find.go
@@ -18,6 +18,7 @@ import (
 	"go/ast"
 	"go/types"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/tools/go/loader"
 )
@@ -146,6 +147,9 @@ func (c *call) HasUndefined() bool {
 			if basic.Kind() == types.Invalid {
 				return true
 			}
+		}
+		if strings.Index(c.Args[i].String(), "invalid type") >= 0 {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
Without this change I was able to run `goderive` on a package that referenced non-existing types, but still was able to generate (invalid) derived code.

Given the same broken package, `goderive` with this chance emits an error instead of completing successfully.