### PR TITLE
deepcopy: fix dup field names for StructOfStructs.

### DIFF
--- a/plugin/deepcopy/deepcopy.go
+++ b/plugin/deepcopy/deepcopy.go
@@ -390,6 +390,8 @@ func (g *gen) genField(fieldType types.Type, thisField, thatField string) error 
 		p.P("}")
 		return nil
 	case *types.Struct:
+		p.P("func() {")
+		p.In()
 		p.P("field := new(%s)", g.TypeString(fieldType))
 		named, isNamed := fieldType.(*types.Named)
 		if isNamed && hasDeepCopyMethod(named) {
@@ -398,6 +400,8 @@ func (g *gen) genField(fieldType types.Type, thisField, thatField string) error 
 			p.P("%s(field, &%s)", g.GetFuncName(types.NewPointer(fieldType)), wrap(thisField))
 		}
 		p.P("%s = *field", thatField)
+		p.Out()
+		p.P("}()")
 		return nil
 	default: // *Chan, *Tuple, *Signature, *Interface, *types.Basic.Kind() == types.UntypedNil, *Struct
 		return fmt.Errorf("unsupported field type %s", g.TypeString(fieldType))

--- a/test/normal/deepcopy_test.go
+++ b/test/normal/deepcopy_test.go
@@ -51,6 +51,7 @@ func TestDeepCopyStructs(t *testing.T) {
 		&Duration{},
 		&Nickname{},
 		&PrivateEmbedded{},
+		&StructOfStructs{},
 	}
 	for _, this := range structs {
 		desc := reflect.TypeOf(this).Elem().Name()

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2210,9 +2210,11 @@ func deriveDeepCopyPtrToEmbeddedStruct1(dst, src *EmbeddedStruct1) {
 
 // deriveDeepCopyPtrToEmbeddedStruct2 recursively copies the contents of src into dst.
 func deriveDeepCopyPtrToEmbeddedStruct2(dst, src *EmbeddedStruct2) {
-	field := new(Structs)
-	src.Structs.DeepCopy(field)
-	dst.Structs = *field
+	func() {
+		field := new(Structs)
+		src.Structs.DeepCopy(field)
+		dst.Structs = *field
+	}()
 	if src.Name == nil {
 		dst.Name = nil
 	} else {
@@ -2429,9 +2431,25 @@ func deriveDeepCopyPtrToNickname(dst, src *Nickname) {
 
 // deriveDeepCopyPtrToPrivateEmbedded recursively copies the contents of src into dst.
 func deriveDeepCopyPtrToPrivateEmbedded(dst, src *PrivateEmbedded) {
-	field := new(privateStruct)
-	deriveDeepCopy_44(field, &src.privateStruct)
-	dst.privateStruct = *field
+	func() {
+		field := new(privateStruct)
+		deriveDeepCopy_44(field, &src.privateStruct)
+		dst.privateStruct = *field
+	}()
+}
+
+// deriveDeepCopyPtrToStructOfStructs recursively copies the contents of src into dst.
+func deriveDeepCopyPtrToStructOfStructs(dst, src *StructOfStructs) {
+	func() {
+		field := new(Structs)
+		src.S1.DeepCopy(field)
+		dst.S1 = *field
+	}()
+	func() {
+		field := new(Structs)
+		src.S2.DeepCopy(field)
+		dst.S2 = *field
+	}()
 }
 
 // deriveContainsInt64s returns whether the item is contained in the list.
@@ -2475,21 +2493,6 @@ func deriveUncurryCurried(f func(b string) func(c bool) string) func(b string, c
 	}
 }
 
-// deriveComposeRetBool composes functions f0 and f1 into one function, that takes the parameters from f0 and returns the results from f1.
-func deriveComposeRetBool(f0 func(string) (string, error), f1 func(string) (bool, error)) func(string) (bool, error) {
-	return func(v_0_0 string) (bool, error) {
-		v_1_0, err0 := f0(v_0_0)
-		if err0 != nil {
-			return false, err0
-		}
-		v_2_0, err1 := f1(v_1_0)
-		if err1 != nil {
-			return false, err1
-		}
-		return v_2_0, nil
-	}
-}
-
 // deriveCompose composes functions f0 and f1 into one function, that takes the parameters from f0 and returns the results from f1.
 func deriveCompose(f0 func() (string, error), f1 func(string) (float64, error)) func() (float64, error) {
 	return func() (float64, error) {
@@ -2530,6 +2533,21 @@ func deriveCompose2(f0 func(string, string) ([]string, string, error), f1 func([
 		v_2_0, err1 := f1(v_1_0, v_1_1)
 		if err1 != nil {
 			return 0, err1
+		}
+		return v_2_0, nil
+	}
+}
+
+// deriveComposeRetBool composes functions f0 and f1 into one function, that takes the parameters from f0 and returns the results from f1.
+func deriveComposeRetBool(f0 func(string) (string, error), f1 func(string) (bool, error)) func(string) (bool, error) {
+	return func(v_0_0 string) (bool, error) {
+		v_1_0, err0 := f0(v_0_0)
+		if err0 != nil {
+			return false, err0
+		}
+		v_2_0, err1 := f1(v_1_0)
+		if err1 != nil {
+			return false, err1
 		}
 		return v_2_0, nil
 	}
@@ -7055,9 +7073,11 @@ func deriveDeepCopy_33(dst, src map[string][]*Name) {
 // deriveDeepCopy_34 recursively copies the contents of src into dst.
 func deriveDeepCopy_34(dst, src map[int]RecursiveType) {
 	for src_key, src_value := range src {
-		field := new(RecursiveType)
-		src_value.DeepCopy(field)
-		dst[src_key] = *field
+		func() {
+			field := new(RecursiveType)
+			src_value.DeepCopy(field)
+			dst[src_key] = *field
+		}()
 	}
 }
 

--- a/test/normal/structs.go
+++ b/test/normal/structs.go
@@ -876,3 +876,11 @@ func (this *PrivateEmbedded) GoString() string {
 func (this *PrivateEmbedded) Hash() uint64 {
 	return deriveHashPrivateEmbedded(this)
 }
+
+type StructOfStructs struct {
+	S1, S2 Structs
+}
+
+func (this *StructOfStructs) DeepCopy(that *StructOfStructs) {
+	deriveDeepCopyPtrToStructOfStructs(that, this)
+}


### PR DESCRIPTION
Prior to this change, if multiple fields in a struct implemented their
own DeepCopy() then the generator would redeclare `field` in the same
scope.