### PR TITLE
fix for issue #58

### DIFF
--- a/plugin/keys/keys.go
+++ b/plugin/keys/keys.go
@@ -55,7 +55,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 
 func (g *gen) Generate(typs []types.Type) error {
 	typ := typs[0]
-	mapType, ok := typ.Underlying().(*types.Map)
+	mapType, ok := typ.(*types.Map)
 	if !ok {
 		return fmt.Errorf("%s, the first argument, %s, is not of type map", g.GetFuncName(typ), typ)
 	}

--- a/plugin/keys/keys.go
+++ b/plugin/keys/keys.go
@@ -55,7 +55,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 
 func (g *gen) Generate(typs []types.Type) error {
 	typ := typs[0]
-	mapType, ok := typ.(*types.Map)
+	mapType, ok := typ.Underlying().(*types.Map)
 	if !ok {
 		return fmt.Errorf("%s, the first argument, %s, is not of type map", g.GetFuncName(typ), typ)
 	}

--- a/test/normal/sortedkeys_test.go
+++ b/test/normal/sortedkeys_test.go
@@ -37,6 +37,24 @@ func TestSortedMapKeysStrings(t *testing.T) {
 	}
 }
 
+func TestSortedMapKeysTypeAlias(t *testing.T) {
+	type aliased map[string]string
+	var unaliased map[string]string
+	m := aliased(random(unaliased).(map[string]string))
+	keys := deriveSortedStrings(deriveKeysForMapStringToString(m))
+	if len(keys) != len(m) {
+		t.Fatalf("length of keys: want %d got %d", len(m), len(keys))
+	}
+	for _, key := range keys {
+		if _, ok := m[key]; !ok {
+			t.Fatalf("key %v does not exist in %#v", key, m)
+		}
+	}
+	if !sort.StringsAreSorted(keys) {
+		t.Fatalf("keys are not sorted %v", keys)
+	}
+}
+
 func TestSortedMapKeysInt(t *testing.T) {
 	var m map[int]int64
 	m = random(m).(map[int]int64)


### PR DESCRIPTION
Fixes #58

deriveKeys now calls .Underlying() on the maptype when checking if applicable