### PR TITLE
fix for issue #60

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # goderive
 
-[![Build Status](https://travis-ci.org/awalterschulze/goderive.svg?branch=master)](https://travis-ci.org/awalterschulze/goderive)
+[![Build Status](https://github.com/awalterschulze/goderive/actions/workflows/go.yaml/badge.svg?branch=master)](https://github.com/awalterschulze/goderive/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/awalterschulze/goderive)](https://goreportcard.com/report/github.com/awalterschulze/goderive)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square.svg)](https://godoc.org/github.com/awalterschulze/goderive)
 

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -4589,6 +4589,12 @@ func deriveSortedStrings(list []string) []string {
 	return list
 }
 
+// deriveSortedStringKeyAlias sorts the slice inplace and also returns it.
+func deriveSortedStringKeyAlias(list []stringKeyAlias) []stringKeyAlias {
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+	return list
+}
+
 // deriveKeysForInt64s returns the keys of the input map as a slice.
 func deriveKeysForInt64s(m map[int64]struct{}) []int64 {
 	keys := make([]int64, 0, len(m))
@@ -4609,6 +4615,24 @@ func deriveKeysForFmap(m map[int]string) []int {
 
 // deriveKeysForMapStringToString returns the keys of the input map as a slice.
 func deriveKeysForMapStringToString(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// deriveKeysForMapStringAliasToString returns the keys of the input map as a slice.
+func deriveKeysForMapStringAliasToString(m map[stringKeyAlias]string) []stringKeyAlias {
+	keys := make([]stringKeyAlias, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// deriveKeysForMapStringToStringAlias returns the keys of the input map as a slice.
+func deriveKeysForMapStringToStringAlias(m map[string]stringAlias) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -4565,6 +4565,24 @@ func deriveSortStructs(list []*BuiltInTypes) []*BuiltInTypes {
 	return list
 }
 
+// deriveSortedSliceIntAlias sorts the slice inplace and also returns it.
+func deriveSortedSliceIntAlias(list []intAlias) []intAlias {
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+	return list
+}
+
+// deriveSortedSliceStringAlias sorts the slice inplace and also returns it.
+func deriveSortedSliceStringAlias(list []stringAlias) []stringAlias {
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+	return list
+}
+
+// deriveSortedSliceFloat64Alias sorts the slice inplace and also returns it.
+func deriveSortedSliceFloat64Alias(list []float64Alias) []float64Alias {
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
+	return list
+}
+
 // deriveSortedStrings sorts the slice inplace and also returns it.
 func deriveSortedStrings(list []string) []string {
 	sort.Strings(list)

--- a/test/normal/derivedthederived_test.go
+++ b/test/normal/derivedthederived_test.go
@@ -14,12 +14,10 @@
 
 package test
 
-import "testing"
-import "reflect"
-
-type DeriveTheDerived struct {
-	Field int
-}
+import (
+	"reflect"
+	"testing"
+)
 
 func inefficientEqual(this, that *DeriveTheDerived) bool {
 	return deriveEqualInefficientDeriveTheDerived(

--- a/test/normal/equal_test.go
+++ b/test/normal/equal_test.go
@@ -182,17 +182,6 @@ func TestCurriedEqual(t *testing.T) {
 	}
 }
 
-type SomeJson struct {
-	Name  string
-	Other KeyValue
-}
-
-type KeyValue map[string]interface{}
-
-func (kv KeyValue) Equal(that KeyValue) bool {
-	return reflect.DeepEqual(kv, that)
-}
-
 func TestMapTypes(t *testing.T) {
 	a := &SomeJson{Name: "a", Other: map[string]interface{}{
 		"b": 1,
@@ -208,11 +197,6 @@ func TestMapTypes(t *testing.T) {
 	if !deriveEqualMapTypes(a, a) {
 		t.Fatalf("expected equal")
 	}
-}
-
-type Visitor struct {
-	UserName   *string
-	RemoteAddr string
 }
 
 func TestEqualStruct(t *testing.T) {

--- a/test/normal/mem_test.go
+++ b/test/normal/mem_test.go
@@ -14,12 +14,10 @@
 
 package test
 
-import "testing"
-import "fmt"
-
-type Adder struct {
-	Int int
-}
+import (
+	"fmt"
+	"testing"
+)
 
 func TestMemGet(t *testing.T) {
 	called := 0

--- a/test/normal/sortalias_test.go
+++ b/test/normal/sortalias_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSortedIntAlias(t *testing.T) {
+	var aliased []intAlias
+	aliased = random(aliased).([]intAlias)
+	got := deriveSortedSliceIntAlias(aliased)
+	if len(aliased) != len(got) {
+		t.Fatalf("length of keys: want %d got %d", len(aliased), len(got))
+	}
+	var unaliased []int
+	for _, val := range aliased {
+		unaliased = append(unaliased, int(val))
+	}
+	if !sort.IntsAreSorted(unaliased) {
+		t.Fatalf("slice are not sorted %v", got)
+	}
+}
+
+func TestSortedStringAlias(t *testing.T) {
+	var aliased []stringAlias
+	aliased = random(aliased).([]stringAlias)
+	got := deriveSortedSliceStringAlias(aliased)
+	if len(aliased) != len(got) {
+		t.Fatalf("length of keys: want %d got %d", len(aliased), len(got))
+	}
+	var unaliased []string
+	for _, val := range aliased {
+		unaliased = append(unaliased, string(val))
+	}
+	if !sort.StringsAreSorted(unaliased) {
+		t.Fatalf("slice are not sorted %v", got)
+	}
+}
+
+func TestSortedFloat64Alias(t *testing.T) {
+	var aliased []float64Alias
+	aliased = random(aliased).([]float64Alias)
+	got := deriveSortedSliceFloat64Alias(aliased)
+	if len(aliased) != len(got) {
+		t.Fatalf("length of keys: want %d got %d", len(aliased), len(got))
+	}
+	var unaliased []float64
+	for _, val := range aliased {
+		unaliased = append(unaliased, float64(val))
+	}
+	if !sort.Float64sAreSorted(unaliased) {
+		t.Fatalf("slice are not sorted %v", got)
+	}
+}

--- a/test/normal/sortedkeys_test.go
+++ b/test/normal/sortedkeys_test.go
@@ -55,6 +55,44 @@ func TestSortedMapKeysTypeAlias(t *testing.T) {
 	}
 }
 
+func TestSortedMapKeysTypeAliasKey(t *testing.T) {
+	var m map[stringKeyAlias]string
+	m = random(m).(map[stringKeyAlias]string)
+	keys := deriveSortedStringKeyAlias(deriveKeysForMapStringAliasToString(m))
+	if len(keys) != len(m) {
+		t.Fatalf("length of keys: want %d got %d", len(m), len(keys))
+	}
+	for _, key := range keys {
+		if _, ok := m[key]; !ok {
+			t.Fatalf("key %v does not exist in %#v", key, m)
+		}
+	}
+	var unaliased []string
+	for _, val := range keys {
+		unaliased = append(unaliased, string(val))
+	}
+	if !sort.StringsAreSorted(unaliased) {
+		t.Fatalf("keys are not sorted %v", keys)
+	}
+}
+
+func TestSortedMapKeysTypeAliasValue(t *testing.T) {
+	var m map[string]stringAlias
+	m = random(m).(map[string]stringAlias)
+	keys := deriveSortedStrings(deriveKeysForMapStringToStringAlias(m))
+	if len(keys) != len(m) {
+		t.Fatalf("length of keys: want %d got %d", len(m), len(keys))
+	}
+	for _, key := range keys {
+		if _, ok := m[key]; !ok {
+			t.Fatalf("key %v does not exist in %#v", key, m)
+		}
+	}
+	if !sort.StringsAreSorted(keys) {
+		t.Fatalf("keys are not sorted %v", keys)
+	}
+}
+
 func TestSortedMapKeysInt(t *testing.T) {
 	var m map[int]int64
 	m = random(m).(map[int]int64)

--- a/test/normal/toerror_test.go
+++ b/test/normal/toerror_test.go
@@ -20,8 +20,6 @@ import (
 	"time"
 )
 
-type LocalType struct{}
-
 func true0() bool {
 	return true
 }
@@ -39,9 +37,6 @@ func true3(a, b int) (int, bool) {
 }
 func true4(a, b int) (int, int, bool) {
 	return a, b, true
-}
-func true5(lt *LocalType) (*LocalType, bool) {
-	return lt, true
 }
 func true6(t *time.Time) (*time.Time, bool) {
 	return t, true

--- a/test/normal/types.go
+++ b/test/normal/types.go
@@ -1,0 +1,7 @@
+package test
+
+type intAlias int
+
+type stringAlias string
+
+type float64Alias float64

--- a/test/normal/types.go
+++ b/test/normal/types.go
@@ -1,7 +1,49 @@
 package test
 
+import (
+	"reflect"
+
+	"vendortest"
+)
+
 type intAlias int
 
 type stringAlias string
 
+type stringKeyAlias string
+
 type float64Alias float64
+
+type LocalType struct{}
+
+func true5(lt *LocalType) (*LocalType, bool) {
+	return lt, true
+}
+
+type DeriveTheDerived struct {
+	Field int
+}
+
+type SomeJson struct {
+	Name  string
+	Other KeyValue
+}
+
+type KeyValue map[string]interface{}
+
+func (kv KeyValue) Equal(that KeyValue) bool {
+	return reflect.DeepEqual(kv, that)
+}
+
+type Visitor struct {
+	UserName   *string
+	RemoteAddr string
+}
+
+type UseVendor struct {
+	Vendors []*vendortest.AVendoredObject
+}
+
+type Adder struct {
+	Int int
+}

--- a/test/normal/vendor_test.go
+++ b/test/normal/vendor_test.go
@@ -2,12 +2,7 @@ package test
 
 import (
 	"testing"
-	"vendortest"
 )
-
-type UseVendor struct {
-	Vendors []*vendortest.AVendoredObject
-}
 
 func TestVendor(t *testing.T) {
 	if !deriveEqual(&UseVendor{}, &UseVendor{}) {


### PR DESCRIPTION
Fixes #60

`deriveSorted` uses `Strings`, `Float64s` and `Ints` functions of `sort` package only if type of the slice element is not aliased.

There is another issue in #60. the author provided some test code. 

```go
type stringalias string

func TestSortedMapKeysTypeAliasKey(t *testing.T) {
    var m map[stringalias]string
    m = random(m).(map[stringalias]string)
    keys := deriveSortedAlias(deriveKeysForMapAliasToString(m))
```

`deriveSortedAlias` is not generated.

I have found that `deriveSortedAlias` never generated if the function's arg is the return value of any generated `goderive` function.

the following test code passes without any issue.

```go
type stringalias string

func TestSortedMapKeysTypeAliasKey(t *testing.T) {
    keys := deriveSortedAlias([]stringalias{"a", "b"})
```

After some testing, I have finally found that if type alias is defined in a normal go file, there is no issue at all.

so, I move the type definitions in `test/normal/*_test.go` files to new `types.go` file.
