### PR TITLE
migrate Travis CI to GItHub Action

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,28 @@
+name: Go
+
+on: [ push, pull_request ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Test
+        run: make test
+
+      - name: Vet
+        run: |
+          go vet ./derive/...
+          go vet ./example/...
+          go vet ./plugin/...
+          go vet ./test/normal/...
+
+      - name: Diff
+        run: git diff --exit-code .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-script:
-  - make travis
-
-language: go
-
-go:
-  - 1.x

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ test:
 gofmt:
 	gofmt -l -s -w .
 
-.PHONY: travis
-travis:
+.PHONY: action
+action:
 	go version
 	make test
 	go vet ./derive/...


### PR DESCRIPTION
This is for rebuilding CI.

- rename `make travis` to `make action`
- remove `.travis.yml`
- create workflow file

You can see the actual run there - https://github.com/jbl428/goderive/actions/runs/908658283