### PR TITLE
Fix/blank identifier

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,6 +14,9 @@ jobs:
         with:
           go-version: 1.16.x
 
+      - name: Gofmt
+        run: make gofmt
+
       - name: Test
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ gofmt:
 	gofmt -l -s -w .
 
 .PHONY: action
-action:
+action: gofmt
 	go version
 	make test
 	go vet ./derive/...

--- a/derive/params.go
+++ b/derive/params.go
@@ -22,12 +22,16 @@ import (
 var blackIdentifier = "_"
 
 // RenameBlankIdentifier returns a signature that all black identified are renamed.
-func RenameBlankIdentifier(sig *types.Signature) *types.Signature {
+func RenameBlankIdentifier(sig *types.Signature, prefixs ...string) *types.Signature {
+	prefix := "param_"
+	if len(prefixs) > 0 {
+		prefix = prefixs[0]
+	}
 	params := sig.Params()
 	if !hasBlankIdentifier(params) {
 		return sig
 	}
-	renamedTuple := rename(params)
+	renamedTuple := rename(params, prefix)
 	return types.NewSignature(sig.Recv(), renamedTuple, sig.Results(), sig.Variadic())
 }
 
@@ -40,12 +44,12 @@ func hasBlankIdentifier(tup *types.Tuple) bool {
 	return false
 }
 
-func rename(tup *types.Tuple) *types.Tuple {
+func rename(tup *types.Tuple, prefix string) *types.Tuple {
 	vars := make([]*types.Var, tup.Len())
 	for i := range vars {
 		varValue := tup.At(i)
 		if varValue.Name() == blackIdentifier {
-			varValue = types.NewVar(varValue.Pos(), varValue.Pkg(), "param_"+strconv.Itoa(i), varValue.Type())
+			varValue = types.NewVar(varValue.Pos(), varValue.Pkg(), prefix+strconv.Itoa(i), varValue.Type())
 		}
 		vars[i] = varValue
 	}

--- a/derive/params.go
+++ b/derive/params.go
@@ -22,12 +22,14 @@ import (
 
 var blackIdentifier = "_"
 
-// RenameBlankIdentifier returns a signature that all black identified are renamed.
-func RenameBlankIdentifier(sig *types.Signature, prefixs ...string) *types.Signature {
-	prefix := "param_"
-	if len(prefixs) > 0 {
-		prefix = prefixs[0]
-	}
+// RenameBlankIdentifier returns a signature where all blank parameter names are renamed.
+func RenameBlankIdentifier(sig *types.Signature) *types.Signature {
+	return RenameBlankIdentifierWith(sig, "param_")
+}
+
+// RenameBlankIdentifierWith returns a signature where all blank parameter names are renamed.
+// The given prefix is used to rename.
+func RenameBlankIdentifierWith(sig *types.Signature, prefix string) *types.Signature {
 	params := sig.Params()
 	if !hasBlankIdentifier(params) {
 		return sig

--- a/derive/params.go
+++ b/derive/params.go
@@ -1,0 +1,53 @@
+//  Copyright 2021 Jake Son
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package derive
+
+import (
+	"go/types"
+	"strconv"
+)
+
+var blackIdentifier = "_"
+
+// RenameBlankIdentifier returns a signature that all black identified are renamed.
+func RenameBlankIdentifier(sig *types.Signature) *types.Signature {
+	params := sig.Params()
+	if !hasBlankIdentifier(params) {
+		return sig
+	}
+	renamedTuple := rename(params)
+	return types.NewSignature(sig.Recv(), renamedTuple, sig.Results(), sig.Variadic())
+}
+
+func hasBlankIdentifier(tup *types.Tuple) bool {
+	for i := 0; i < tup.Len(); i++ {
+		if tup.At(i).Name() == blackIdentifier {
+			return true
+		}
+	}
+	return false
+}
+
+func rename(tup *types.Tuple) *types.Tuple {
+	vars := make([]*types.Var, tup.Len())
+	for i := range vars {
+		varValue := tup.At(i)
+		if varValue.Name() == blackIdentifier {
+			varValue = types.NewVar(varValue.Pos(), varValue.Pkg(), "param_"+strconv.Itoa(i), varValue.Type())
+		}
+		vars[i] = varValue
+	}
+	return types.NewTuple(vars...)
+}

--- a/derive/params.go
+++ b/derive/params.go
@@ -17,6 +17,7 @@ package derive
 import (
 	"go/types"
 	"strconv"
+	"strings"
 )
 
 var blackIdentifier = "_"
@@ -48,7 +49,7 @@ func rename(tup *types.Tuple, prefix string) *types.Tuple {
 	vars := make([]*types.Var, tup.Len())
 	for i := range vars {
 		varValue := tup.At(i)
-		if varValue.Name() == blackIdentifier {
+		if varValue.Name() == blackIdentifier || strings.HasPrefix(varValue.Name(), prefix) {
 			varValue = types.NewVar(varValue.Pos(), varValue.Pkg(), prefix+strconv.Itoa(i), varValue.Type())
 		}
 		vars[i] = varValue

--- a/plugin/apply/apply.go
+++ b/plugin/apply/apply.go
@@ -47,11 +47,11 @@ type gen struct {
 }
 
 func (g *gen) Add(name string, typs []types.Type) (string, error) {
-	sig, _, err := g.parseTypes(name, typs)
+	sig, lastArg, err := g.parseTypes(name, typs)
 	if err != nil {
 		return "", err
 	}
-	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig), typs[1])
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig), lastArg)
 }
 
 func (g *gen) parseTypes(name string, typs []types.Type) (sig *types.Signature, lastArg types.Type, err error) {

--- a/plugin/apply/apply.go
+++ b/plugin/apply/apply.go
@@ -47,10 +47,11 @@ type gen struct {
 }
 
 func (g *gen) Add(name string, typs []types.Type) (string, error) {
-	if _, _, err := g.parseTypes(name, typs); err != nil {
+	sig, _, err := g.parseTypes(name, typs)
+	if err != nil {
 		return "", err
 	}
-	return g.SetFuncName(name, typs...)
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig), typs[1])
 }
 
 func (g *gen) parseTypes(name string, typs []types.Type) (sig *types.Signature, lastArg types.Type, err error) {
@@ -74,8 +75,8 @@ func (g *gen) parseTypes(name string, typs []types.Type) (sig *types.Signature, 
 
 func applySig(sig *types.Signature) (last *types.Var, returnFunc *types.Signature) {
 	vs := vars(sig.Params())
-	last = vs[len(vs) - 1]
-	second := types.NewTuple(vs[:len(vs) - 1]...)
+	last = vs[len(vs)-1]
+	second := types.NewTuple(vs[:len(vs)-1]...)
 	returnFunc = types.NewSignature(nil, second, sig.Results(), sig.Variadic())
 	return
 }
@@ -95,6 +96,7 @@ func varnames(tup *types.Tuple) []string {
 	}
 	return as
 }
+
 func (g *gen) Generate(typs []types.Type) error {
 	name := g.GetFuncName(typs...)
 	ftyp, lastArg, err := g.parseTypes(name, typs)
@@ -120,4 +122,3 @@ func (g *gen) Generate(typs []types.Type) error {
 	p.P("}")
 	return nil
 }
-

--- a/plugin/curry/curry.go
+++ b/plugin/curry/curry.go
@@ -58,7 +58,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if params.Len() < 2 {
 		return "", fmt.Errorf("%s, the first argument is a function, but wanted a function with more than one argument", name)
 	}
-	return g.SetFuncName(name, sig)
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))
 }
 
 func (g *gen) Generate(typs []types.Type) error {

--- a/plugin/flip/flip.go
+++ b/plugin/flip/flip.go
@@ -58,7 +58,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if params.Len() < 2 {
 		return "", fmt.Errorf("%s, the first argument is a function, but wanted a function with more than one argument", name)
 	}
-	return g.SetFuncName(name, sig)
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))
 }
 
 func (g *gen) Generate(typs []types.Type) error {

--- a/plugin/toerror/toerror.go
+++ b/plugin/toerror/toerror.go
@@ -66,7 +66,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if !types.Identical(results.At(results.Len()-1).Type(), types.Typ[types.Bool]) {
 		return "", fmt.Errorf("%s, given function must return bool as last return type. (got %v)", name, results.String())
 	}
-	return g.SetFuncName(name, funcTyp)
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))
 }
 
 func (g *gen) Generate(typs []types.Type) error {

--- a/plugin/uncurry/uncurry.go
+++ b/plugin/uncurry/uncurry.go
@@ -66,7 +66,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("%s, does not return a function", name)
 	}
-	retSig = derive.RenameBlankIdentifier(retSig, "innerParam_")
+	retSig = derive.RenameBlankIdentifierWith(retSig, "innerParam_")
 	newTup := types.NewTuple(types.NewVar(retVar.Pos(), retVar.Pkg(), retVar.Name(), retSig))
 	sig = types.NewSignature(sig.Recv(), sig.Params(), newTup, sig.Variadic())
 	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))

--- a/plugin/uncurry/uncurry.go
+++ b/plugin/uncurry/uncurry.go
@@ -61,9 +61,14 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if sig.Results().Len() != 1 {
 		return "", fmt.Errorf("%s, expected 1 result for the input function", name)
 	}
-	if _, ok := sig.Results().At(0).Type().(*types.Signature); !ok {
+	retVar := sig.Results().At(0)
+	retSig, ok := retVar.Type().(*types.Signature)
+	if !ok {
 		return "", fmt.Errorf("%s, does not return a function", name)
 	}
+	retSig = derive.RenameBlankIdentifier(retSig, "innerParam_")
+	newTup := types.NewTuple(types.NewVar(retVar.Pos(), retVar.Pkg(), retVar.Name(), retSig))
+	sig = types.NewSignature(sig.Recv(), sig.Params(), newTup, sig.Variadic())
 	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))
 }
 

--- a/plugin/uncurry/uncurry.go
+++ b/plugin/uncurry/uncurry.go
@@ -64,7 +64,7 @@ func (g *gen) Add(name string, typs []types.Type) (string, error) {
 	if _, ok := sig.Results().At(0).Type().(*types.Signature); !ok {
 		return "", fmt.Errorf("%s, does not return a function", name)
 	}
-	return g.SetFuncName(name, sig)
+	return g.SetFuncName(name, derive.RenameBlankIdentifier(sig))
 }
 
 func (g *gen) Generate(typs []types.Type) error {

--- a/test/normal/apply_test.go
+++ b/test/normal/apply_test.go
@@ -56,3 +56,15 @@ func TestApplyApplied(t *testing.T) {
 		t.Fatalf("got %s != want %s", got, want)
 	}
 }
+
+func TestApplyBlankIdentifier(t *testing.T) {
+	f := func(a string, _ bool, c int) string {
+		return fmt.Sprintf("%s%v%d", a, true, c)
+	}
+	applied := deriveApplyBlankIdentifier(f, 1)
+	want := `atrue1`
+	got := applied("a", false)
+	if got != want {
+		t.Fatalf("got %s != want %s", got, want)
+	}
+}

--- a/test/normal/curry_test.go
+++ b/test/normal/curry_test.go
@@ -57,3 +57,15 @@ func TestCurryCurried(t *testing.T) {
 		t.Fatalf("got %s != want %s", got, want)
 	}
 }
+
+func TestCurryBlankIdentifier(t *testing.T) {
+	f := func(a string, _ bool, c int) string {
+		return fmt.Sprintf("%s%v%d", a, true, c)
+	}
+	curried := deriveCurryBlackIdentifier(f)
+	want := `atrue1`
+	got := curried("a")(false, 1)
+	if got != want {
+		t.Fatalf("got %s != want %s", got, want)
+	}
+}

--- a/test/normal/curry_test.go
+++ b/test/normal/curry_test.go
@@ -59,8 +59,8 @@ func TestCurryCurried(t *testing.T) {
 }
 
 func TestCurryBlankIdentifier(t *testing.T) {
-	f := func(a string, _ bool, c int) string {
-		return fmt.Sprintf("%s%v%d", a, true, c)
+	f := func(param_1 string, _ bool, param_0 int) string {
+		return fmt.Sprintf("%s%v%d", param_1, true, param_0)
 	}
 	curried := deriveCurryBlackIdentifier(f)
 	want := `atrue1`

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2504,9 +2504,9 @@ func deriveUncurryCurried(f func(b string) func(c bool) string) func(b string, c
 }
 
 // deriveUncurryBlankIdentifier combines a function that returns a function, into one function.
-func deriveUncurryBlankIdentifier(f func(param_0 string) func(inner_param0 bool, c int) string) func(param_0 string, inner_param0 bool, c int) string {
-	return func(param_0 string, inner_param0 bool, c int) string {
-		return f(param_0)(inner_param0, c)
+func deriveUncurryBlankIdentifier(f func(param_0 string) func(innerParam_0 bool, c int) string) func(param_0 string, innerParam_0 bool, c int) string {
+	return func(param_0 string, innerParam_0 bool, c int) string {
+		return f(param_0)(innerParam_0, c)
 	}
 }
 

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -4469,10 +4469,10 @@ func deriveCurryCurried(f func(b string, c bool) string) func(b string) func(c b
 }
 
 // deriveCurryBlackIdentifier returns a function that has one parameter, which corresponds to the input functions first parameter, and a result that is a function, which takes the rest of the parameters as input and finally returns the original input function's results.
-func deriveCurryBlackIdentifier(f func(a string, param_1 bool, c int) string) func(a string) func(param_1 bool, c int) string {
-	return func(a string) func(param_1 bool, c int) string {
-		return func(param_1 bool, c int) string {
-			return f(a, param_1, c)
+func deriveCurryBlackIdentifier(f func(param_0 string, param_1 bool, param_2 int) string) func(param_0 string) func(param_1 bool, param_2 int) string {
+	return func(param_0 string) func(param_1 bool, param_2 int) string {
+		return func(param_1 bool, param_2 int) string {
+			return f(param_0, param_1, param_2)
 		}
 	}
 }

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2504,9 +2504,9 @@ func deriveUncurryCurried(f func(b string) func(c bool) string) func(b string, c
 }
 
 // deriveUncurryBlankIdentifier combines a function that returns a function, into one function.
-func deriveUncurryBlankIdentifier(f func(param_0 string) func(b bool, c int) string) func(param_0 string, b bool, c int) string {
-	return func(param_0 string, b bool, c int) string {
-		return f(param_0)(b, c)
+func deriveUncurryBlankIdentifier(f func(param_0 string) func(inner_param0 bool, c int) string) func(param_0 string, inner_param0 bool, c int) string {
+	return func(param_0 string, inner_param0 bool, c int) string {
+		return f(param_0)(inner_param0, c)
 	}
 }
 

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2503,6 +2503,13 @@ func deriveUncurryCurried(f func(b string) func(c bool) string) func(b string, c
 	}
 }
 
+// deriveUncurryBlankIdentifier combines a function that returns a function, into one function.
+func deriveUncurryBlankIdentifier(f func(param_0 string) func(b bool, c int) string) func(param_0 string, b bool, c int) string {
+	return func(param_0 string, b bool, c int) string {
+		return f(param_0)(b, c)
+	}
+}
+
 // deriveToError0 transforms the given function's last bool type into an error type. The transformed function returns the given error when the result of the given function is false, otherwise it returns nil.
 func deriveToError0(err error, f func() bool) func() error {
 	return func() error {
@@ -2573,6 +2580,17 @@ func deriveToError5(err error, f func(lt *LocalType) (*LocalType, bool)) func(lt
 func deriveToError6(err error, f func(t *time.Time) (*time.Time, bool)) func(t *time.Time) (*time.Time, error) {
 	return func(t *time.Time) (*time.Time, error) {
 		out0, success := f(t)
+		if success {
+			return out0, nil
+		}
+		return out0, err
+	}
+}
+
+// deriveToError7 transforms the given function's last bool type into an error type. The transformed function returns the given error when the result of the given function is false, otherwise it returns nil.
+func deriveToError7(err error, f func(param_0 string) (string, bool)) func(param_0 string) (string, error) {
+	return func(param_0 string) (string, error) {
+		out0, success := f(param_0)
 		if success {
 			return out0, nil
 		}
@@ -4450,6 +4468,15 @@ func deriveCurryCurried(f func(b string, c bool) string) func(b string) func(c b
 	}
 }
 
+// deriveCurryBlackIdentifier returns a function that has one parameter, which corresponds to the input functions first parameter, and a result that is a function, which takes the rest of the parameters as input and finally returns the original input function's results.
+func deriveCurryBlackIdentifier(f func(a string, param_1 bool, c int) string) func(a string) func(param_1 bool, c int) string {
+	return func(a string) func(param_1 bool, c int) string {
+		return func(param_1 bool, c int) string {
+			return f(a, param_1, c)
+		}
+	}
+}
+
 // deriveCloneEmpty returns a clone of the src parameter.
 func deriveCloneEmpty(src *Empty) *Empty {
 	if src == nil {
@@ -4572,6 +4599,13 @@ func deriveApply3(f func(a string, b int, c bool) string, c bool) func(a string,
 func deriveApplyApplied(f func(a string, b int) string, b int) func(a string) string {
 	return func(a string) string {
 		return f(a, b)
+	}
+}
+
+// deriveApplyBlankIdentifier applies the second argument to a given function's last argument and returns a function which which takes the rest of the parameters as input and finally returns the original input function's results.
+func deriveApplyBlankIdentifier(f func(a string, param_1 bool, c int) string, c int) func(a string, param_1 bool) string {
+	return func(a string, param_1 bool) string {
+		return f(a, param_1, c)
 	}
 }
 
@@ -5460,6 +5494,13 @@ func deriveFlipMarshal(f func(data []byte, v interface{}) error) func(v interfac
 func deriveFlip3(f func(a int, b string, c bool) string) func(b string, a int, c bool) string {
 	return func(b string, a int, c bool) string {
 		return f(a, b, c)
+	}
+}
+
+// deriveFlipBlankIdentifier returns the input function, but where first two parameters are flipped.
+func deriveFlipBlankIdentifier(f func(a string, param_1 bool, c int) string) func(param_1 bool, a string, c int) string {
+	return func(param_1 bool, a string, c int) string {
+		return f(a, param_1, c)
 	}
 }
 

--- a/test/normal/flip_test.go
+++ b/test/normal/flip_test.go
@@ -43,3 +43,15 @@ func TestFlip3(t *testing.T) {
 		t.Fatalf("got %s != want %s", got, want)
 	}
 }
+
+func TestFlipBlankIdentifier(t *testing.T) {
+	f := func(a string, _ bool, c int) string {
+		return fmt.Sprintf("%s%v%d", a, true, c)
+	}
+	flipped := deriveFlipBlankIdentifier(f)
+	want := `atrue1`
+	got := flipped(false, "a", 1)
+	if got != want {
+		t.Fatalf("got %s != want %s", got, want)
+	}
+}

--- a/test/normal/toerror_test.go
+++ b/test/normal/toerror_test.go
@@ -41,6 +41,9 @@ func true4(a, b int) (int, int, bool) {
 func true6(t *time.Time) (*time.Time, bool) {
 	return t, true
 }
+func true7(_ string) (string, bool) {
+	return "a", true
+}
 
 func TestToError(t *testing.T) {
 	e := fmt.Errorf("error")
@@ -68,6 +71,9 @@ func TestToError(t *testing.T) {
 	}
 	tm := time.Now()
 	if r0, r1 := deriveToError6(e, true6)(&tm); !(r0 == &tm && r1 == nil) {
+		t.Fatal()
+	}
+	if r0, r1 := deriveToError7(e, true7)("z"); !(r0 == "a" && r1 == nil) {
 		t.Fatal()
 	}
 }

--- a/test/normal/uncurry_test.go
+++ b/test/normal/uncurry_test.go
@@ -62,8 +62,8 @@ func TestUncurryCurried(t *testing.T) {
 }
 
 func TestUncurryBlankIdentifier(t *testing.T) {
-	curried := func(_ string) func(b bool, c int) string {
-		return func(b bool, c int) string {
+	curried := func(_ string) func(_ bool, c int) string {
+		return func(_ bool, c int) string {
 			return "ature1"
 		}
 	}

--- a/test/normal/uncurry_test.go
+++ b/test/normal/uncurry_test.go
@@ -60,3 +60,17 @@ func TestUncurryCurried(t *testing.T) {
 		t.Fatalf("got %s != want %s", got, want)
 	}
 }
+
+func TestUncurryBlankIdentifier(t *testing.T) {
+	curried := func(_ string) func(b bool, c int) string {
+		return func(b bool, c int) string {
+			return "ature1"
+		}
+	}
+	uncurried := deriveUncurryBlankIdentifier(curried)
+	want := `ature1`
+	got := uncurried("z", false, 0)
+	if got != want {
+		t.Fatalf("got %s != want %s", got, want)
+	}
+}


### PR DESCRIPTION
Resolve #67 

Rename blank identifier to `prefix` + `position of parameter`.
Default prefix is `param_`.

Following plugins use rename function.

- apply
- curry
- flip
- toError
- uncurry
