### PR TITLE
Feature/deepcopy add type alias support

### DIFF
--- a/derive/plugin.go
+++ b/derive/plugin.go
@@ -46,9 +46,10 @@ type plugin struct {
 
 // NewPlugin is used by a plugin library to create a plugin, that can be added to the Plugins list.
 // For example:
-//   func NewPlugin() derive.Plugin {
-//     return derive.NewPlugin("all", "deriveAll", New)
-//   }
+//
+//	func NewPlugin() derive.Plugin {
+//	  return derive.NewPlugin("all", "deriveAll", New)
+//	}
 func NewPlugin(name, prefix string, newFunc func(typesMap TypesMap, p Printer, deps map[string]Dependency) Generator) Plugin {
 	return &plugin{
 		name:    name,

--- a/derive/typesmap.go
+++ b/derive/typesmap.go
@@ -32,8 +32,13 @@ type TypesMap interface {
 	Prefix() string
 	TypeString(typ types.Type) string
 	FieldStrings(fields []*types.Var) ([]string, error)
-	IsExternal(typ *types.Named) bool
+	IsExternal(typ ObjectGetter) bool
 	Done() bool
+}
+
+// ObjectGetter is implemented by both [types.Named] and [types.Alias].
+type ObjectGetter interface {
+	Obj() *types.TypeName
 }
 
 type typesMap struct {
@@ -86,7 +91,7 @@ func (tm *typesMap) TypeStringBypass(typ types.Type) string {
 	return types.TypeString(types.Default(typ), bypassQual)
 }
 
-func (tm *typesMap) IsExternal(typ *types.Named) bool {
+func (tm *typesMap) IsExternal(typ ObjectGetter) bool {
 	q := tm.qual(typ.Obj().Pkg())
 	return q != ""
 }

--- a/example/pluginprefix/example.go
+++ b/example/pluginprefix/example.go
@@ -2,7 +2,7 @@
 // have to start with default "deriveEqual" prefix.
 // in the Makefile we can see the goderive command being called:
 //
-//   goderive --pluginprefix="equal=eq" ./...
+//	goderive --pluginprefix="equal=eq" ./...
 //
 // This sets the new prefix to "eq".
 package pluginprefix

--- a/example/prefix/example.go
+++ b/example/prefix/example.go
@@ -2,7 +2,7 @@
 // have to start with default "deriveEqual" prefix.
 // in the Makefile we can see the goderive command being called:
 //
-//   goderive --prefix="generate" ./...
+//	goderive --prefix="generate" ./...
 //
 // This sets the new prefix to "generate".
 package prefix

--- a/plugin/apply/apply.go
+++ b/plugin/apply/apply.go
@@ -15,7 +15,8 @@
 // Package apply contains the implementation of the apply plugin, which generates the deriveApply function.
 //
 // The deriveApply function applies the given argument to a given function and returns a function which requires filling in the other arguments.
-//   deriveApply(f func(...A, B) C, B) func(...A) C
+//
+//	deriveApply(f func(...A, B) C, B) func(...A) C
 package apply
 
 import (

--- a/plugin/clone/clone.go
+++ b/plugin/clone/clone.go
@@ -15,22 +15,25 @@
 // Package clone contains the implementation of the clone plugin, which generates the deriveClone function.
 //
 // The deriveClone function is a maintainable and fast way to implement fast"ish" clone functions.
-//   func deriveClone(T) T
+//
+//	func deriveClone(T) T
+//
 // I say fast"ish", since deriveClone creates a totally new copy of the value, whereas deepcopy reuses as much as of the memory that has been allocated by the destintation value.
 //
 // Supported types:
-//	- basic types
-//	- named structs
-//	- slices
-//	- maps
-//	- pointers to these types
-//	- private fields of structs in external packages (using reflect and unsafe)
-//	- and many more
+//   - basic types
+//   - named structs
+//   - slices
+//   - maps
+//   - pointers to these types
+//   - private fields of structs in external packages (using reflect and unsafe)
+//   - and many more
+//
 // Unsupported types:
-//	- chan
-//	- interface
-//	- function
-//	- unnamed structs, which are not comparable with the == operator
+//   - chan
+//   - interface
+//   - function
+//   - unnamed structs, which are not comparable with the == operator
 package clone
 
 import (

--- a/plugin/compose/compose.go
+++ b/plugin/compose/compose.go
@@ -15,10 +15,11 @@
 // Package compose contains the implementation of the compose plugin, which generates the deriveCompose function.
 //
 // The deriveCompose function composes multiple functions that return an error into one function.
-//    deriveCompose(func() (A, error), func(A) (B, error)) func() (B, error)
-//    deriveCompose(func(A) (B, error), func(B) (C, error)) func(A) (C, error)
-//    deriveCompose(func(A...) (B..., error), func(B...) (C..., error)) func(A...) (C..., error)
-//    deriveCompose(func(A...) (B..., error), ..., func(C...) (D..., error)) func(A...) (D..., error)
+//
+//	deriveCompose(func() (A, error), func(A) (B, error)) func() (B, error)
+//	deriveCompose(func(A) (B, error), func(B) (C, error)) func(A) (C, error)
+//	deriveCompose(func(A...) (B..., error), func(B...) (C..., error)) func(A...) (C..., error)
+//	deriveCompose(func(A...) (B..., error), ..., func(C...) (D..., error)) func(A...) (D..., error)
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/compose

--- a/plugin/curry/curry.go
+++ b/plugin/curry/curry.go
@@ -15,7 +15,8 @@
 // Package curry contains the implementation of the curry plugin, which generates the deriveCurry function.
 //
 // The deriveCurry function curries the first two parameters of the input function.
-//   deriveCurry(f func(A, B, ...) T) func(A) func(B, ...) T
+//
+//	deriveCurry(f func(A, B, ...) T) func(A) func(B, ...) T
 package curry
 
 import (

--- a/plugin/deepcopy/deepcopy.go
+++ b/plugin/deepcopy/deepcopy.go
@@ -424,6 +424,6 @@ func (g *gen) genField(fieldType types.Type, thisField, thatField string) error 
 		p.P("}()")
 		return nil
 	default: // *Chan, *Tuple, *Signature, *Interface, *types.Basic.Kind() == types.UntypedNil, *Struct
-		return fmt.Errorf("unsupported field type %s", g.TypeString(fieldType))
+		return fmt.Errorf("unsupported field type %s %s", thisField, g.TypeString(fieldType))
 	}
 }

--- a/plugin/deepcopy/deepcopy.go
+++ b/plugin/deepcopy/deepcopy.go
@@ -143,7 +143,6 @@ func (g *gen) genStatement(typ types.Type, this, that string) error {
 	switch ttyp := typ.Underlying().(type) {
 	case *types.Pointer:
 		reftyp := ttyp.Elem()
-		g.TypeString(reftyp)
 		thisref, thatref := "*"+this, "*"+that
 
 		var objGetter derive.ObjectGetter

--- a/plugin/deepcopy/deepcopy.go
+++ b/plugin/deepcopy/deepcopy.go
@@ -409,7 +409,9 @@ func (g *gen) genField(fieldType types.Type, thisField, thatField string) error 
 		p.P("}")
 		return nil
 	case *types.Struct:
-		p.P("func() {")
+		// Confine field copy to a new block to prevent ghosting `field` variable.
+		// Required especially because `field` variable name is static and is overwritten/different types if you have more than one field.
+		p.P("{")
 		p.In()
 		p.P("field := new(%s)", g.TypeString(fieldType))
 		named, isNamed := fieldType.(*types.Named)
@@ -420,7 +422,7 @@ func (g *gen) genField(fieldType types.Type, thisField, thatField string) error 
 		}
 		p.P("%s = *field", thatField)
 		p.Out()
-		p.P("}()")
+		p.P("}")
 		return nil
 	default: // *Chan, *Tuple, *Signature, *Interface, *types.Basic.Kind() == types.UntypedNil, *Struct
 		return fmt.Errorf("unsupported field type %s %s", thisField, g.TypeString(fieldType))

--- a/plugin/deepcopy/deepcopy.go
+++ b/plugin/deepcopy/deepcopy.go
@@ -17,8 +17,8 @@
 // The deriveDeepCopy function is a maintainable and fast way to implement fast copy functions.
 //
 // When goderive walks over your code it is looking for a function that:
-//  - was not implemented (or was previously derived) and
-//  - has a predefined prefix.
+//   - was not implemented (or was previously derived) and
+//   - has a predefined prefix.
 //
 // In the following code the deriveDeepCopy function will be found, because
 // it was not implemented and it has a prefix deriveDeepCopy.
@@ -29,7 +29,7 @@
 //	import "sort"
 //
 //	type MyStruct struct {
-// 		Int64     int64
+//		Int64     int64
 //		StringPtr *string
 //	}
 //
@@ -43,25 +43,27 @@
 //	}
 //
 // The initial type that is passed into deriveDeepCopy needs to have a reference type:
-//	- pointer
-//	- slice
-//	- map
+//   - pointer
+//   - slice
+//   - map
+//
 // , otherwise we are not able to modify the input parameter and then what are you really copying,
 // but as we go deeper we support most types.
 //
 // Supported types:
-//	- basic types
-//	- named structs
-//	- slices
-//	- maps
-//	- pointers to these types
-//	- private fields of structs in external packages (using reflect and unsafe)
-//	- and many more
+//   - basic types
+//   - named structs
+//   - slices
+//   - maps
+//   - pointers to these types
+//   - private fields of structs in external packages (using reflect and unsafe)
+//   - and many more
+//
 // Unsupported types:
-//	- chan
-//	- interface
-//	- function
-//	- unnamed structs, which are not comparable with the == operator
+//   - chan
+//   - interface
+//   - function
+//   - unnamed structs, which are not comparable with the == operator
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/deepcopy

--- a/plugin/do/do.go
+++ b/plugin/do/do.go
@@ -15,59 +15,70 @@
 // Package do contains the implementation of the do plugin, which generates the deriveDo function.
 //
 // The deriveDo function executes a list of functions concurrently and returns their results.
-//   deriveDo(func() (A, error), func (B, error)) (A, B, error)
+//
+//	deriveDo(func() (A, error), func (B, error)) (A, B, error)
+//
 // Each function is executed in a go routine and the first error is returned.
 // It waits for all functions to complete.
 //
 // The concept is stolen from applicative do in haskell or rather haxl.
 // http://simonmar.github.io/bib/papers/applicativedo.pdf
 // The applicative do rewrites the monadic do notation:
-//   do {
-//       a <- f
-//       b <- g
-//       return (f, g)
-//   }
+//
+//	do {
+//	    a <- f
+//	    b <- g
+//	    return (f, g)
+//	}
+//
 // To:
-//   (,) <$> f <*> g
+//
+//	(,) <$> f <*> g
+//
 // When it detects that the functions do not depend on one another.
 // Haskell type signatures that will hopefully help to explain.
 // Fmap:
-//   <$> :: (a -> b) -> m a -> m b
+//
+//	<$> :: (a -> b) -> m a -> m b
+//
 // Ap:
-//   <*> :: m (a -> b) -> m a -> m b
+//
+//	<*> :: m (a -> b) -> m a -> m b
 //
 // In go this could be:
-//   func newTuple(a A, b B) func() (A, B) {
-//       return func() (A, B) {
-//           return a, b
-//       }
-//   }
-//   deriveAp(
-//       deriveFmap(
-//           newTuple,
-//           f,
-//       )
-//       g,
-//   )
-//   func deriveFmap(
-//       newTuple func(A, B) func() (A, B),
-//       f func() (A, error),
-//       ) func(B) (func() (A, B), error) {
-//           return func(b B) (func() (A, B), error) {
-//               a, err := f()
-//               if err != nil {
-//                   return nil, err
-//               }
-//               return newTuple(a, b), nil
-//           }
-//   }
-//   func deriveAp(fmapped func(B) (func() (A, B), error), g func() (B, error)) (func() (A, B), error) {
-//       b, err := g()
-//       if err != nil {
-//           return nil, err
-//       }
-//       return fmapped(b)
-//   }
+//
+//	func newTuple(a A, b B) func() (A, B) {
+//	    return func() (A, B) {
+//	        return a, b
+//	    }
+//	}
+//	deriveAp(
+//	    deriveFmap(
+//	        newTuple,
+//	        f,
+//	    )
+//	    g,
+//	)
+//	func deriveFmap(
+//	    newTuple func(A, B) func() (A, B),
+//	    f func() (A, error),
+//	    ) func(B) (func() (A, B), error) {
+//	        return func(b B) (func() (A, B), error) {
+//	            a, err := f()
+//	            if err != nil {
+//	                return nil, err
+//	            }
+//	            return newTuple(a, b), nil
+//	        }
+//	}
+//	func deriveAp(fmapped func(B) (func() (A, B), error), g func() (B, error)) (func() (A, B), error) {
+//	    b, err := g()
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return fmapped(b)
+//	}
+//
 // derviveDo builds on this, but requires the programmer to explicitly call deriveDo
 //
 // Example output can be found here:

--- a/plugin/dup/dup.go
+++ b/plugin/dup/dup.go
@@ -15,7 +15,8 @@
 // Package dup contains the implementation of the dup plugin, which generates the deriveDup function.
 //
 // The deriveDup duplicates messages received on c to both c1 and c2.
-//   deriveDup(c <-chan T) (c1, c2 <-chan T)
+//
+//	deriveDup(c <-chan T) (c1, c2 <-chan T)
 package dup
 
 import (

--- a/plugin/equal/equal.go
+++ b/plugin/equal/equal.go
@@ -15,12 +15,13 @@
 // Package equal contains the implementation of the equal plugin, which generates the deriveEqual function.
 //
 // The deriveEqual function is a faster alternative to reflect.DeepEqual.
-//   deriveEqual(T, T) bool
-//   deriveEqual(T) func(T) bool
+//
+//	deriveEqual(T, T) bool
+//	deriveEqual(T) func(T) bool
 //
 // When goderive walks over your code it is looking for a function that:
-//  - was not implemented (or was previously derived) and
-//  - has a predefined prefix.
+//   - was not implemented (or was previously derived) and
+//   - has a predefined prefix.
 //
 // In the following code the deriveEqual function will be found, because
 // it was not implemented and it has a prefix deriveEqual.
@@ -48,18 +49,19 @@
 //	}
 //
 // Supported types:
-//	- basic types
-//	- named structs
-//	- slices
-//	- maps
-//	- pointers to these types
-//	- private fields of structs in external packages (using reflect and unsafe)
-//	- and many more
+//   - basic types
+//   - named structs
+//   - slices
+//   - maps
+//   - pointers to these types
+//   - private fields of structs in external packages (using reflect and unsafe)
+//   - and many more
+//
 // Unsupported types:
-//	- chan
-//	- interface
-//	- function
-//	- unnamed structs, which are not comparable with the == operator
+//   - chan
+//   - interface
+//   - function
+//   - unnamed structs, which are not comparable with the == operator
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/equal

--- a/plugin/flip/flip.go
+++ b/plugin/flip/flip.go
@@ -15,7 +15,8 @@
 // Package flip contains the implementation of the flip plugin, which generates the deriveFlip function.
 //
 // The deriveFlip function flips the first two parameters of the input function.
-//   deriveFlip(f func(A, B, ...) T) func(B, A, ...) T
+//
+//	deriveFlip(f func(A, B, ...) T) func(B, A, ...) T
 package flip
 
 import (

--- a/plugin/fmap/fmap.go
+++ b/plugin/fmap/fmap.go
@@ -15,18 +15,23 @@
 // Package fmap contains the implementation of the fmap plugin, which generates the deriveFmap function.
 //
 // The deriveFmap function applies a given function to each element of a list, returning a list of results in the same order.
-//   deriveFmap(func(A) B, []A) []B
-//   deriveFmap(func(rune) B, string) []B
+//
+//	deriveFmap(func(A) B, []A) []B
+//	deriveFmap(func(rune) B, string) []B
 //
 // deriveFmap can also be applied to a function that returns a value and an error.
-//   deriveFmap(func(A) B, func() (A, error)) (B, error)
-//   deriveFmap(func(A) (B, error), func() (A, error)) (func() (B, error), error)
-//   deriveFmap(func(A), func() (A, error)) error
-//   deriveFmap(func(A) (B, c, d, ...), func() (A, error)) (func() (B, c, d, ...), error)
+//
+//	deriveFmap(func(A) B, func() (A, error)) (B, error)
+//	deriveFmap(func(A) (B, error), func() (A, error)) (func() (B, error), error)
+//	deriveFmap(func(A), func() (A, error)) error
+//	deriveFmap(func(A) (B, c, d, ...), func() (A, error)) (func() (B, c, d, ...), error)
+//
 // deriveFmap will propagate the error and not apply the first function to the result of the second function, if the second function returns an error.
 //
 // deriveFmap can also be applied to a channel.
-//   deriveFmap(func(A) B, <-chan A) <-chan B
+//
+//	deriveFmap(func(A) B, <-chan A) <-chan B
+//
 // deriveFmap will return the output channel immediately and start up a go routine in the background to process the incoming channel.
 package fmap
 

--- a/plugin/gostring/gostring.go
+++ b/plugin/gostring/gostring.go
@@ -18,8 +18,8 @@
 // The deriveGoString function does a recursive print, even printing pointer values, unlike the default %#v operand.
 //
 // When goderive walks over your code it is looking for a function that:
-//  - was not implemented (or was previously derived) and
-//  - has a predefined prefix.
+//   - was not implemented (or was previously derived) and
+//   - has a predefined prefix.
 //
 // In the following code the deriveGoString function will be found, because
 // it was not implemented and it has a prefix deriveGoString.
@@ -45,18 +45,19 @@
 // GoString does a recursive print, even printing pointer values, unlike the default %#v operand.
 //
 // Supported types:
-//	- basic types
-//	- named structs
-//	- slices
-//	- maps
-//	- pointers to these types
-//	- and many more
+//   - basic types
+//   - named structs
+//   - slices
+//   - maps
+//   - pointers to these types
+//   - and many more
+//
 // Unsupported types:
-//	- chan
-//	- interface
-//	- function
-//	- private fields
-//	- unnamed structs
+//   - chan
+//   - interface
+//   - function
+//   - private fields
+//   - unnamed structs
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/gostring

--- a/plugin/hash/hash.go
+++ b/plugin/hash/hash.go
@@ -15,20 +15,22 @@
 // Package hash contains the implementation of the hash plugin, which generates the deriveHash function.
 //
 // The deriveHash function is returns a hash of the input object.
-//   deriveHash(T) uint64
+//
+//	deriveHash(T) uint64
 //
 // Supported types:
-//	- basic types
-//	- named structs
-//	- slices
-//	- maps
-//	- pointers to these types
-//	- and many more
+//   - basic types
+//   - named structs
+//   - slices
+//   - maps
+//   - pointers to these types
+//   - and many more
+//
 // Unsupported types:
-//	- chan
-//	- interface
-//	- function
-//	- unnamed structs, which are not comparable with the == operator
+//   - chan
+//   - interface
+//   - function
+//   - unnamed structs, which are not comparable with the == operator
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/hash

--- a/plugin/join/join.go
+++ b/plugin/join/join.go
@@ -15,22 +15,28 @@
 // Package join contains the implementation of the join plugin, which generates the deriveJoin function.
 //
 // The deriveJoin function joins a slice of slices into a single slice.
-//    deriveJoin([][]T) []T
-//    deriveJoin([]string) string
+//
+//	deriveJoin([][]T) []T
+//	deriveJoin([]string) string
 //
 // The deriveJoin function also joins two tuples, both with errors, into a single tuple with a single error.
-//    deriveJoin(func() (T, error), error) func() (T, error)
-//    deriveJoin(func() error, error) func() error
-//    deriveJoin(func() (T, ..., error), error) func() (T, ..., error)
+//
+//	deriveJoin(func() (T, error), error) func() (T, error)
+//	deriveJoin(func() error, error) func() error
+//	deriveJoin(func() (T, ..., error), error) func() (T, ..., error)
 //
 // The deriveJoin function can also join channels
-//    deriveJoin(<-chan <-chan T) <-chan T
-//    deriveJoin(chan <-chan T) <-chan T
-//    deriveJoin([]<-chan T) <-chan T
-//    deriveJoin([]chan T) <-chan T
+//
+//	deriveJoin(<-chan <-chan T) <-chan T
+//	deriveJoin(chan <-chan T) <-chan T
+//	deriveJoin([]<-chan T) <-chan T
+//	deriveJoin([]chan T) <-chan T
+//
 // deriveJoin immediately return the output channel and start up a go routine to process the main incoming channel.
 // It will then start up a go routine to listen on every new incoming channel and send those events to the outgoing channel.
-//    deriveJoin(chan T, chan T, ...) <-chan T
+//
+//	deriveJoin(chan T, chan T, ...) <-chan T
+//
 // deriveJoin with a variable number of channels as parameter will do a select over those channels, until all are closed.
 package join
 

--- a/plugin/mem/mem.go
+++ b/plugin/mem/mem.go
@@ -15,8 +15,8 @@
 // Package mem contains the implementation of the mem plugin, which generates the deriveMem function.
 //
 // The deriveMem function returns a memoized version of the input function.
-//   func deriveMem(func(A) B) func(A) B
 //
+//	func deriveMem(func(A) B) func(A) B
 package mem
 
 import (

--- a/plugin/pipeline/pipeline.go
+++ b/plugin/pipeline/pipeline.go
@@ -15,7 +15,8 @@
 // Package pipeline contains the implementation of the pipeline plugin, which generates the derivePipeline function.
 //
 // The derivePipeline starts up a concurrent pipeline of the given functions.
-//   derivePipeline(func(A) <-chan B, func(B) <-chan C) func(A) <-chan C
+//
+//	derivePipeline(func(A) <-chan B, func(B) <-chan C) func(A) <-chan C
 //
 // Example output can be found here:
 // https://github.com/awalterschulze/goderive/tree/master/example/plugin/pipeline

--- a/plugin/toerror/toerror.go
+++ b/plugin/toerror/toerror.go
@@ -15,7 +15,8 @@
 // Package toerror contains the implementation of the toerror plugin, which generates the deriveToError function.
 //
 // The deriveToError function transforms return type of a function from (B..., bool) into (B..., error).
-//   deriveToError(e error, f func(A...) (B..., bool)) func(A...) (B..., error)
+//
+//	deriveToError(e error, f func(A...) (B..., bool)) func(A...) (B..., error)
 package toerror
 
 import (

--- a/plugin/traverse/traverse.go
+++ b/plugin/traverse/traverse.go
@@ -15,7 +15,8 @@
 // Package traverse contains the implementation of the traverse plugin, which generates the deriveTraverse function.
 //
 // The deriveTraverse function applies a given function to each element of a list, returning a list of results in the same order or an error.
-//   deriveTraverse(func(A) (B, error), []A) ([]B, error)
+//
+//	deriveTraverse(func(A) (B, error), []A) ([]B, error)
 package traverse
 
 import (

--- a/plugin/tuple/tuple.go
+++ b/plugin/tuple/tuple.go
@@ -15,7 +15,9 @@
 // Package tuple contains the implementation of the tuple plugin, which generates the deriveTuple function.
 //
 // The deriveTuple function takes its input parameters and returns a function that returns those parameters.
-//   deriveTuple(A, B, ...) func() (A, B, ...)
+//
+//	deriveTuple(A, B, ...) func() (A, B, ...)
+//
 // deriveTuple is useful, since a tuple is not a first class citizen in go, but a function that returns a tuple is.
 package tuple
 

--- a/plugin/uncurry/uncurry.go
+++ b/plugin/uncurry/uncurry.go
@@ -15,7 +15,8 @@
 // Package uncurry contains the implementation of the uncurry plugin, which generates the deriveUncurry function.
 //
 // The deriveUncurry function uncurries the input function.
-//   deriveUncurry(f func(A) func(B, ...) T) func(A, B, ...) T
+//
+//	deriveUncurry(f func(A) func(B, ...) T) func(A, B, ...) T
 package uncurry
 
 import (

--- a/test/normal/deepcopy_test.go
+++ b/test/normal/deepcopy_test.go
@@ -104,22 +104,48 @@ func (c customMap) DeepCopy(to customMap) {
 	}
 }
 
-type SimpleStruct struct {
+type SimpleStructWithDeepCopy struct {
 	Level int
 }
 
-func (this *SimpleStruct) DeepCopy(that *SimpleStruct) {
-	deriveDeepCopySimpleStruct(that, this)
+func (this *SimpleStructWithDeepCopy) DeepCopy(that *SimpleStructWithDeepCopy) {
+	deriveDeepCopySimpleStructWithDeepCopy(that, this)
 }
 
-type aliasToStruct = SimpleStruct
+// Check DeepCopy defined on aliased struct
+type aliasToSimpleStructWithDeepCopy = SimpleStructWithDeepCopy
 
 func TestDeepCopyAlias(t *testing.T) {
-	this := &aliasToStruct{
+	this := &aliasToSimpleStructWithDeepCopy{
 		Level: 99,
 	}
 
-	that := &aliasToStruct{}
+	that := &aliasToSimpleStructWithDeepCopy{}
+
+	deepcopy(this, that)
+
+	if that.Level != this.Level {
+		t.Error("expected level to use copied value")
+	}
+}
+
+type SimpleStructWithoutDeepCopy struct {
+	Level int
+}
+
+type aliasWithMethod = SimpleStructWithoutDeepCopy
+
+// Check method defined on alias.
+func (this *aliasWithMethod) DeepCopy(that *aliasWithMethod) {
+	deriveDeepCopyAliasWithMethod(that, this)
+}
+
+func TestDeepCopyAliasWithMethod(t *testing.T) {
+	this := &aliasWithMethod{
+		Level: 99,
+	}
+
+	that := &aliasWithMethod{}
 
 	deepcopy(this, that)
 

--- a/test/normal/deepcopy_test.go
+++ b/test/normal/deepcopy_test.go
@@ -103,3 +103,27 @@ func (c customMap) DeepCopy(to customMap) {
 		to[k] = "copy of " + v
 	}
 }
+
+type SimpleStruct struct {
+	Level int
+}
+
+func (this *SimpleStruct) DeepCopy(that *SimpleStruct) {
+	deriveDeepCopySimpleStruct(that, this)
+}
+
+type aliasToStruct = SimpleStruct
+
+func TestDeepCopyAlias(t *testing.T) {
+	this := &aliasToStruct{
+		Level: 99,
+	}
+
+	that := &aliasToStruct{}
+
+	deepcopy(this, that)
+
+	if that.Level != this.Level {
+		t.Error("expected level to use copied value")
+	}
+}

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2318,11 +2318,11 @@ func deriveDeepCopyPtrToEmbeddedStruct1(dst, src *EmbeddedStruct1) {
 
 // deriveDeepCopyPtrToEmbeddedStruct2 recursively copies the contents of src into dst.
 func deriveDeepCopyPtrToEmbeddedStruct2(dst, src *EmbeddedStruct2) {
-	func() {
+	{
 		field := new(Structs)
 		src.Structs.DeepCopy(field)
 		dst.Structs = *field
-	}()
+	}
 	if src.Name == nil {
 		dst.Name = nil
 	} else {
@@ -2545,25 +2545,25 @@ func deriveDeepCopyPtrToNickname(dst, src *Nickname) {
 
 // deriveDeepCopyPtrToPrivateEmbedded recursively copies the contents of src into dst.
 func deriveDeepCopyPtrToPrivateEmbedded(dst, src *PrivateEmbedded) {
-	func() {
+	{
 		field := new(privateStruct)
 		deriveDeepCopy_50(field, &src.privateStruct)
 		dst.privateStruct = *field
-	}()
+	}
 }
 
 // deriveDeepCopyPtrToStructOfStructs recursively copies the contents of src into dst.
 func deriveDeepCopyPtrToStructOfStructs(dst, src *StructOfStructs) {
-	func() {
+	{
 		field := new(Structs)
 		src.S1.DeepCopy(field)
 		dst.S1 = *field
-	}()
-	func() {
+	}
+	{
 		field := new(Structs)
 		src.S2.DeepCopy(field)
 		dst.S2 = *field
-	}()
+	}
 }
 
 // deriveDeepCopySimpleStruct recursively copies the contents of src into dst.
@@ -7822,11 +7822,11 @@ func deriveDeepCopy_39(dst, src map[string][]*StructWithoutMethod) {
 // deriveDeepCopy_40 recursively copies the contents of src into dst.
 func deriveDeepCopy_40(dst, src map[int]RecursiveType) {
 	for src_key, src_value := range src {
-		func() {
+		{
 			field := new(RecursiveType)
 			src_value.DeepCopy(field)
 			dst[src_key] = *field
-		}()
+		}
 	}
 }
 

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2566,6 +2566,11 @@ func deriveDeepCopyPtrToStructOfStructs(dst, src *StructOfStructs) {
 	}()
 }
 
+// deriveDeepCopySimpleStruct recursively copies the contents of src into dst.
+func deriveDeepCopySimpleStruct(dst, src *SimpleStruct) {
+	dst.Level = src.Level
+}
+
 // deriveContainsInt64s returns whether the item is contained in the list.
 //
 // Deprecated: In favour of generics.

--- a/test/normal/derived.gen.go
+++ b/test/normal/derived.gen.go
@@ -2566,8 +2566,13 @@ func deriveDeepCopyPtrToStructOfStructs(dst, src *StructOfStructs) {
 	}
 }
 
-// deriveDeepCopySimpleStruct recursively copies the contents of src into dst.
-func deriveDeepCopySimpleStruct(dst, src *SimpleStruct) {
+// deriveDeepCopySimpleStructWithDeepCopy recursively copies the contents of src into dst.
+func deriveDeepCopySimpleStructWithDeepCopy(dst, src *SimpleStructWithDeepCopy) {
+	dst.Level = src.Level
+}
+
+// deriveDeepCopyAliasWithMethod recursively copies the contents of src into dst.
+func deriveDeepCopyAliasWithMethod(dst, src *aliasWithMethod) {
 	dst.Level = src.Level
 }
 


### PR DESCRIPTION
Adds support for deep copying type aliases.

Type aliases in go are the following form:

```
type MyOtherType struct {...}

type MyAlias = MyOtherType
```

Typically they are used for code migration but are also more prevalent with code using generics to make aliases for generic parameters that also have methods implemented. Named types do not inherit the implemented methods.

- Includes an additional change to print field names of unsupoprted field types.  This helps with large struct trees that might have a simple type like `any` embedded in them. Makes it much easier to figure where on the tree this any field is.